### PR TITLE
fixed docker login

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -14,10 +14,14 @@ jobs:
         run: |
           docker build -f Dockerfile.dev -t chatroom-syncer .
           docker tag chatroom-syncer weygu/chatroom-syncer:latest
-      - name: Push Docker image
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          docker push weygu/chatroom-syncer:latest
+      - name: Log into DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64
+          tags: weygu/chatroom-syncer:latest
+          push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,9 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push Docker images
         uses: docker/build-push-action@v3
+        env:
+          # tag name, removed prefix "v"
+          VERSION: ${{ github.event.release.tag_name }}
         with:
           platforms: linux/amd64
           tags: weygu/chatroom-syncer:latest, weygu/chatroom-syncer:$VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,12 +32,14 @@ jobs:
           docker build -t chatroom-syncer .
           docker tag chatroom-syncer username/chatroom-syncer:$VERSION
           docker tag chatroom-syncer username/chatroom-syncer:latest
-      - name: Push Docker image
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          VERSION: ${{ github.event.release.tag_name }}
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          docker push username/chatroom-syncer:$VERSION
-          docker push username/chatroom-syncer:latest
+      - name: Log into DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64
+          tags: weygu/chatroom-syncer:latest, weygu/chatroom-syncer:$VERSION
+          push: true


### PR DESCRIPTION
```
Run echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
  docker push weygu/chatroom-syncer:latest
  shell: /usr/bin/bash -e {0}
  env:
    DOCKER_USERNAME: 
    DOCKER_PASSWORD: 
Must provide --username with --password-stdin
Error: Process completed with exit code 1.
```

fixed this, later we should leverage the corresponding official actions for build, too, to easier enable arm64 image being pushed, too.